### PR TITLE
Fix Python 3.13 compatibility on Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-watchdog==4.0.0
+watchdog>=6.0.0
 Flask==3.1.0
 Pillow==11.0.0


### PR DESCRIPTION
## Summary
- Updates watchdog dependency from 4.0.0 to >=6.0.0 to fix Python 3.13 compatibility on Windows

## Problem
Colleagues running the tool on Windows with Python 3.13 encountered a `TypeError: 'handle' must be a _ThreadHandle` error when the watchdog observer tried to start. This is a known incompatibility between watchdog 4.0.0 and Python 3.13.

## Solution
Upgraded watchdog to version 6.0.0+ which includes official Python 3.13 support with proper wheel files for all platforms including Windows.

## Test plan
- [x] Tested on macOS with Python 3.13 - working
- [ ] Windows users should test with `pip install --upgrade -r requirements.txt` and verify the app starts without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)