### PR TITLE
Fix Windows image path issues in Flask UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -343,19 +343,18 @@ def index():
                          settings=settings)
 
 
-@app.route('/file/<path:filepath>')
-def file_detail(filepath):
+@app.route('/file/<filename>')
+def file_detail(filename):
     """Detail page for a specific file"""
-    # Add leading slash if missing (happens with absolute paths in URLs)
-    if not filepath.startswith('/'):
-        filepath = '/' + filepath
+    settings = load_settings()
+    watch_folder = Path(settings['watch_folder']).resolve()
+    file_path = watch_folder / filename
 
-    file_info = get_file_info(filepath)
+    file_info = get_file_info(str(file_path))
     if not file_info:
         return "File not found", 404
 
-    exif_data = get_exif_data(filepath)
-    settings = load_settings()
+    exif_data = get_exif_data(str(file_path))
 
     return render_template('file_detail.html',
                          file=file_info,
@@ -377,18 +376,18 @@ def api_files():
     return jsonify(files_info)
 
 
-@app.route('/api/file/<path:filepath>')
-def api_file_detail(filepath):
+@app.route('/api/file/<filename>')
+def api_file_detail(filename):
     """API endpoint for file details"""
-    # Add leading slash if missing (happens with absolute paths in URLs)
-    if not filepath.startswith('/'):
-        filepath = '/' + filepath
+    settings = load_settings()
+    watch_folder = Path(settings['watch_folder']).resolve()
+    file_path = watch_folder / filename
 
-    file_info = get_file_info(filepath)
+    file_info = get_file_info(str(file_path))
     if not file_info:
         return jsonify({'error': 'File not found'}), 404
 
-    exif_data = get_exif_data(filepath)
+    exif_data = get_exif_data(str(file_path))
 
     return jsonify({
         'file': file_info,
@@ -396,34 +395,32 @@ def api_file_detail(filepath):
     })
 
 
-@app.route('/image/<path:filepath>')
-def serve_image(filepath):
+@app.route('/image/<filename>')
+def serve_image(filename):
     """Serve image file"""
-    # Add leading slash if missing
-    if not filepath.startswith('/'):
-        filepath = '/' + filepath
+    settings = load_settings()
+    watch_folder = Path(settings['watch_folder']).resolve()
+    file_path = watch_folder / filename
 
-    path = Path(filepath)
-    if not path.exists() or not path.is_file():
+    if not file_path.exists() or not file_path.is_file():
         return "Image not found", 404
 
-    return send_file(filepath, mimetype='image/jpeg')
+    return send_file(str(file_path), mimetype='image/jpeg')
 
 
-@app.route('/thumbnail/<path:filepath>')
-def serve_thumbnail(filepath):
+@app.route('/thumbnail/<filename>')
+def serve_thumbnail(filename):
     """Serve thumbnail version of image"""
-    # Add leading slash if missing
-    if not filepath.startswith('/'):
-        filepath = '/' + filepath
+    settings = load_settings()
+    watch_folder = Path(settings['watch_folder']).resolve()
+    file_path = watch_folder / filename
 
-    path = Path(filepath)
-    if not path.exists() or not path.is_file():
+    if not file_path.exists() or not file_path.is_file():
         return "Image not found", 404
 
     # Create thumbnail
     try:
-        img = Image.open(path)
+        img = Image.open(file_path)
         img.thumbnail((300, 300))
 
         # Save to a temporary BytesIO object

--- a/templates/file_detail.html
+++ b/templates/file_detail.html
@@ -279,7 +279,7 @@
 </head>
 <body>
     <div class="image-header">
-        <img src="{{ url_for('serve_image', filepath=file.path) }}" alt="{{ file.name }}">
+        <img src="{{ url_for('serve_image', filename=file.name) }}" alt="{{ file.name }}">
         <div class="image-overlay"></div>
 
         <div class="header-nav">
@@ -293,7 +293,7 @@
     <!-- Lightbox -->
     <div class="lightbox" id="lightbox">
         <span class="lightbox-close" id="lightbox-close">&times;</span>
-        <img src="{{ url_for('serve_image', filepath=file.path) }}" alt="{{ file.name }}" id="lightbox-img">
+        <img src="{{ url_for('serve_image', filename=file.name) }}" alt="{{ file.name }}" id="lightbox-img">
     </div>
 
     <div class="tabs">

--- a/templates/index.html
+++ b/templates/index.html
@@ -206,8 +206,8 @@
         {% if files %}
         <div class="files-grid">
             {% for file in files %}
-            <div class="file-card" onclick="window.location.href='{{ url_for('file_detail', filepath=file.path) }}'">
-                <img src="{{ url_for('serve_thumbnail', filepath=file.path) }}" alt="{{ file.name }}" class="file-thumbnail">
+            <div class="file-card" onclick="window.location.href='{{ url_for('file_detail', filename=file.name) }}'">
+                <img src="{{ url_for('serve_thumbnail', filename=file.name) }}" alt="{{ file.name }}" class="file-thumbnail">
                 <div class="file-card-content">
                     <div class="file-name">{{ file.name }}</div>
                     <div class="file-info">


### PR DESCRIPTION
## Summary
- Fixed image display issues on Windows when using Firefox (and other browsers)
- Changed Flask routes to use filenames instead of full absolute paths in URLs
- Routes now construct full paths server-side from watch_folder + filename
- Updated templates to pass `file.name` instead of `file.path` to image/thumbnail URLs

## Problem
On Windows, absolute file paths (like `C:\Users\...`) were being passed directly in URLs, which caused browsers to fail loading images. The URLs contained drive letters and backslashes that don't work properly in web contexts.

## Solution
All image-serving routes (`serve_image`, `serve_thumbnail`, `file_detail`, `api_file_detail`) now accept only the filename as a URL parameter and reconstruct the full path server-side. This ensures clean, platform-independent URLs like:
- `http://192.168.1.100:5001/image/photo.jpg`
- `http://192.168.1.100:5001/thumbnail/photo.jpg`

## Test plan
- [ ] Test on Windows with Firefox that images display correctly in the UI
- [ ] Verify thumbnails load on index page
- [ ] Verify full images load on detail page
- [ ] Test on macOS to ensure no regression
- [ ] Verify lightbox functionality still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)