### PR TITLE
Add environment configuration and credentials management

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-WIKIMEDIA_USERNAME=''
-WIKIMEDIA_PASSWORD=''
-WIKIMEDIA_USER_AGENT='KB-DelpherUpdater/1.0 (olaf.janssen@kb.nl) - Olaf Janssen, KB, national library of the Netherlands'

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Wikimedia Commons credentials for upload
+COMMONS_USERNAME='your_username@bot_name'
+COMMONS_PASSWORD='your_bot_password'
+
+# Optional: Custom user agent
+WIKIMEDIA_USER_AGENT='uploader tool (MacOS-to-Commons-Uploader) - @your_username (your@email.com)'

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,5 @@
-# Watched files
-watch/*
-!watch/.gitkeep
-
-# Processed files database
-data/processed_files.json
+# Environment variables with credentials
+.env
 
 # Python
 __pycache__/
@@ -11,15 +7,38 @@ __pycache__/
 *$py.class
 *.so
 .Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
 venv/
-env/
 ENV/
+env/
 
 # IDE
 .vscode/
 .idea/
 *.swp
 *.swo
+*~
 
-# macOS
+# OS
 .DS_Store
+Thumbs.db
+
+# Application data
+data/
+watch/
+*.log

--- a/app.py
+++ b/app.py
@@ -56,7 +56,10 @@ except Exception as e:
     build_checker_session = None  # type: ignore
 
 # Load environment (.env) for Commons upload credentials
-load_dotenv()
+# Look for .env in parent directory (repository root) first, then current directory
+repo_root = Path(__file__).parent.parent.parent
+load_dotenv(repo_root / '.env')
+load_dotenv()  # Also check current directory as fallback
 COMMONS_USERNAME = os.getenv("COMMONS_USERNAME", "").strip()
 COMMONS_PASSWORD = os.getenv("COMMONS_PASSWORD", "").strip()
 


### PR DESCRIPTION
## Summary
- Added `.gitignore` to prevent committing sensitive credentials
- Added `.env.example` template for credential configuration
- Updated `app.py` to load `.env` from repository root for sharing across Conductor branches
- Removed `.env` from git tracking to protect credentials

## Benefits
- Credentials stored in repository root are shared across all Conductor workspace branches
- `.gitignore` prevents accidental credential commits
- `.env.example` provides clear template for new users
- Cleaner credential management workflow

## Test plan
- [ ] Verify `.env.example` provides clear template
- [ ] Test that app.py loads credentials from repository root
- [ ] Confirm `.env` is not tracked by git
- [ ] Verify application works with credentials in repository root

🤖 Generated with [Claude Code](https://claude.com/claude-code)